### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,87 @@
 # Deez Factors
-Looks for people in the GitHub organization that do not have 2-factor
-authentication turned on. Now you can tell your users to `Get Deez Factors!`
+An audit tool to look for people in a GitHub organization with the primary purpose of locating users that do not have Two-factor authentication turned on. Now you can tell your users to "Get Deez Factors!"
 
-## How to set it up
-You need to set an environment variable, `GITHUB_API_KEY`, either in your
-shell or by adding it to a file called `.env` in the format `GITHUB_API_KEY:blahblah`.
-The token I used was a GitHub Personal Access Token. Then you just run the program with the org name.
+**Note:** In order to view users who have 2FA disabled, you must be an admin/owner of the organization for which you are checking. Refer to the GitHub API Documentation [audit-two-factor-auth](https://developer.github.com/v3/orgs/members/#audit-two-factor-auth).
 
-`deez_factors microsoft`
+**Note:** In order to check the membership of users, you must belong to that organization. Refer to the GitHub API Documentation [get-organization-membership](https://developer.github.com/v3/orgs/members/#get-organization-membership)
+
+## Usage
+```
+$ ./deez_factors --help
+usage: deez_factors --org=ORG [<flags>]
+
+Flags:
+      --help                 Show context-sensitive help (also try --help-long and --help-man).
+      --org=ORG              Name of the GitHub organization.
+      --token=TOKEN          GitHub Personal API Token.
+      --whitelist=WHITELIST  Path to user whitelist file
+  -e, --env                  Use the .env file or variable GITHUB_API_KEY.
+  -d, --disable-filter       Disables the user filter
+```
+
+ - Organization (Required): The name of the organzation on GitHub 
+    - `--org=microsoft`
+ - Token: The Personal API token used to query the GitHub API 
+    - `--token=api_key`
+ - Whitelist: The absolute or relative path to a whitelist file of users. Whitelist can be composed of either user names or email addresses (does not work if user's email is private)
+   - `--whitelist=/Users/user/Desktop/whitelist.txt`
+ - Env: Overrides `--token` and reads either the environment variable GITHUB_API_KEY or a .env file
+ - Disable-Filter: Disables the '2fa_disabled' user filter. Can be used to validate output if you are not a organization owner.
+
+### Environment Variable
+If not using the `--token` flag, do one of the following and provide the `-e` flag:
+
+```bash
+export GITHUB_API_KEY=api_key
+```
+OR
+```bash
+echo "api_key" > .env
+```
+
+### Whitelist
+A whitelist can be used to avoid printing out specific users either by specifying their username or email address (if public):
+
+```
+username1
+user@somedomain.com
+username2
+```
+
+## Examples
+Providing organization without a GITHUB_API_KEY
+
+```
+$ ./deez_factors --org=microsoft
+Invalid GITHUB_API_KEY value
+```
+
+User is not an owner of the organization
+
+```
+$ ./deez_factors --org=microsoft --token=api_token
+Only owners can use the 2fa_disabled filter
+See https://developer.github.com/v3/orgs/members/#audit-two-factor-auth
+* - denotes organization admin
+```
+
+Disable the `2fa_disabled` filter so you can view users
+
+```
+$ ./deez_factors.go -d --org=microsoft --token=api_token
+01: [ ] user1 (John Doe) - N/A
+02: [ ] user2 (John Schmoe) - user2@gmail.com
+03: [ ] user3 (N/A) - N/A
+04: [ ] user4 (N/A) - N/A
+05: [ ] user5 (Joe Dirt) - N/A
+06: [*] user6 (Thomas the Tank) - user6@gmail.com
+...
+* - denotes organization admin
+```
+
+Specifying an invalid GITHUB_API_KEY
+
+```
+./deez_factors -d --org=microsoft --token=invalid_api_key
+401 Unauthorized. Invalid token?
+```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Deez Factors
-An audit tool to look for people in a GitHub organization with the primary purpose of locating users that do not have Two-factor authentication turned on. Now you can tell your users to "Get Deez Factors!"
+An audit tool written in Go to look for people in a GitHub organization with the primary purpose of locating users that do not have Two-factor authentication turned on. Now you can tell your users to "Get Deez Factors!"
 
 **Note:** In order to view users who have 2FA disabled, you must be an admin/owner of the organization for which you are checking. Refer to the GitHub API Documentation [audit-two-factor-auth](https://developer.github.com/v3/orgs/members/#audit-two-factor-auth).
 
 **Note:** In order to check the membership of users, you must belong to that organization. Refer to the GitHub API Documentation [get-organization-membership](https://developer.github.com/v3/orgs/members/#get-organization-membership)
 
 ## Usage
+
+```
+go install github.com/blackfist/deez_factors
+```
+
 ```
 $ ./deez_factors --help
 usage: deez_factors --org=ORG [<flags>]

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -51,6 +51,7 @@ func main() {
     api_token := kingpin.Flag("token", "GitHub Personal API Token.").String()
     whitelist := kingpin.Flag("whitelist", "Path to whitelist file, does not print users in whitelist").String()
     use_env := kingpin.Flag("env", "Use the .env file or variable GITHUB_API_KEY.").Short('e').Bool()
+    filter := kingpin.Flag("disable-filter", "Disables the user filter").Short('d').Bool()
 
     kingpin.Parse()
 
@@ -75,6 +76,12 @@ func main() {
         }
     }
 
+    // If specified, remove the user filter, otherwise default to "2fa_disabled"
+    user_filter := ""
+    if !*filter {
+        user_filter = "2fa_disabled"
+    }
+
   // Authenticate to GitHub
   ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *api_token})
   tc := oauth2.NewClient(oauth2.NoContext, ts)
@@ -86,7 +93,7 @@ func main() {
   // Need to use a loop because there may be multiple pages
   // of users.
   var allUsers []*github.User
-  options := &github.ListMembersOptions{Filter: "2fa_disabled"}
+  options := &github.ListMembersOptions{Filter: user_filter}
   for {
     users, response, _ := client.Organizations.ListMembers(*org_name, options)
     allUsers = append(allUsers, users...)

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -80,7 +80,7 @@ func main() {
   // Get a list of org members that don't have 2FA enabled
   // Need to use a loop because there may be multiple pages
   // of users.
-  var allUsers []github.User
+  var allUsers []*github.User
   options := &github.ListMembersOptions{Filter: "2fa_disabled"}
   for {
     users, response, _ := client.Organizations.ListMembers(org_name, options)

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -1,48 +1,48 @@
 package main
 
 import (
-  "fmt"
-  "os"
-  "bufio"
-  "strings"
-  "github.com/joho/godotenv"
-  "github.com/google/go-github/github"
-  "golang.org/x/oauth2"
-  "gopkg.in/alecthomas/kingpin.v2"
+    "fmt"
+    "os"
+    "bufio"
+    "strings"
+    "github.com/joho/godotenv"
+    "github.com/google/go-github/github"
+    "golang.org/x/oauth2"
+    "gopkg.in/alecthomas/kingpin.v2"
 )
 
 func readWhitelist(path string) ([]string, error) {
-  var lines []string
-  file, err := os.Open(path)
+    var lines []string
+    file, err := os.Open(path)
 
-  // There might be a problem opening the file. If so,
-  // return the error
-  if err != nil {
-    return lines, err
-  }
-
-  // No error, so make sure we close the file when we're done
-  defer file.Close()
-
-  // Now read it into an array
-  scanner := bufio.NewScanner(file)
-  for scanner.Scan() {
-    if strings.HasPrefix(scanner.Text(), "#") {
-      // skip lines that start with #
-      continue
+    // There might be a problem opening the file. If so,
+    // return the error
+    if err != nil {
+        return lines, err
     }
-    lines = append(lines, scanner.Text())
-  }
-  return lines, nil
+
+    // No error, so make sure we close the file when we're done
+    defer file.Close()
+
+    // Now read it into an array
+    scanner := bufio.NewScanner(file)
+    for scanner.Scan() {
+        if strings.HasPrefix(scanner.Text(), "#") {
+            // skip lines that start with #
+            continue
+        }
+        lines = append(lines, scanner.Text())
+    }
+    return lines, nil
 }
 
 func checkWhiteList(name string, whitelist []string) (bool) {
-  for _, value := range whitelist {
-    if name == value {
-      return true
+    for _, value := range whitelist {
+        if name == value {
+            return true
+        }
     }
-  }
-  return false
+    return false
 }
 
 func main() {
@@ -82,41 +82,41 @@ func main() {
         user_filter = "2fa_disabled"
     }
 
-  // Authenticate to GitHub
-  ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *api_token})
-  tc := oauth2.NewClient(oauth2.NoContext, ts)
+    // Authenticate to GitHub
+    ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *api_token})
+    tc := oauth2.NewClient(oauth2.NoContext, ts)
 
-  // Create a GitHub client using the token from above
-  client := github.NewClient(tc)
+    // Create a GitHub client using the token from above
+    client := github.NewClient(tc)
 
-  // Get a list of org members that don't have 2FA enabled
-  // Need to use a loop because there may be multiple pages
-  // of users.
-  var allUsers []*github.User
-  options := &github.ListMembersOptions{Filter: user_filter}
-  for {
-    users, response, _ := client.Organizations.ListMembers(*org_name, options)
-    allUsers = append(allUsers, users...)
-    if response.NextPage == 0 {
-      break
+    // Get a list of org members that don't have 2FA enabled
+    // Need to use a loop because there may be multiple pages
+    // of users.
+    var allUsers []*github.User
+    options := &github.ListMembersOptions{Filter: user_filter}
+    for {
+        users, response, _ := client.Organizations.ListMembers(*org_name, options)
+        allUsers = append(allUsers, users...)
+        if response.NextPage == 0 {
+        break
+        }
+        options.ListOptions.Page = response.NextPage
     }
-    options.ListOptions.Page = response.NextPage
-  }
 
-  // Loop over the list of users and print their name
-  // User structs store values as pointers so we need to use
-  // the * to get the value
+    // Loop over the list of users and print their name
+    // User structs store values as pointers so we need to use
+    // the * to get the value
 
-  // Also need to use a different counter than the one that
-  // comes with range because otherwise when we skip
-  // whitelisted rows we end up with gaps in the numbers
-  counter := 1
-  for _, v := range allUsers {
-    // If the user is whitelisted, then move on
-    if (len(*whitelist) > 0) {
-      if checkWhiteList(*v.Login, wlist) {
-        continue
-      }
+    // Also need to use a different counter than the one that
+    // comes with range because otherwise when we skip
+    // whitelisted rows we end up with gaps in the numbers
+    counter := 1
+    for _, v := range allUsers {
+        // If the user is whitelisted, then move on
+        if (len(*whitelist) > 0) {
+            if checkWhiteList(*v.Login, wlist) {
+            continue
+        }
     }
     
     // Try to get more information about the user

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -1,5 +1,18 @@
 package main
 
+// TODO: Add check for username or email to compare to whitelist
+// TODO: Update output
+// TODO: Allow for custom filter
+// TODO: Add check for site owner
+// TODO: Add warning if not owner of organization
+/* 
+> "https://api.github.com/orgs/optiv/members?filter=2fa_disabled"
+{
+  "message": "Only owners can use this filter.",
+  "documentation_url": "https://developer.github.com/v3/orgs/members/#audit-two-factor-auth"
+}
+*/
+
 import (
     "fmt"
     "os"

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -96,10 +96,13 @@ func main() {
     for {
         users, response, err := client.Organizations.ListMembers(*org_name, options)
         if err != nil {
-            if strings.Contains(strings.ToLower(err.Error()), "only owners") {
+            if strings.Contains(err.Error(), "401") {
+                color.Red("401 Unauthorized. Invalid token?")
+                os.Exit(1)
+            } else if strings.Contains(strings.ToLower(err.Error()), "only owners") {
                 color.Yellow("Only owners can use the 2fa_disabled filter")
                 color.Yellow("See https://developer.github.com/v3/orgs/members/#audit-two-factor-auth")
-            }
+            } 
         }
         allUsers = append(allUsers, users...)
         if response.NextPage == 0 {

--- a/deez_factors.go
+++ b/deez_factors.go
@@ -1,6 +1,5 @@
 package main
 
-// TODO: Add check for site owner
 // TODO: Add option for output CSV
 // TODO: Create generator for GitHub users
 // TODO: Add warning if not owner of organization
@@ -105,6 +104,8 @@ func main() {
     options := &github.ListMembersOptions{Filter: user_filter}
     for {
         users, response, _ := client.Organizations.ListMembers(*org_name, options)
+        //fmt.Println(users)
+        //fmt.Println(response)
         allUsers = append(allUsers, users...)
         if response.NextPage == 0 {
             break
@@ -119,9 +120,16 @@ func main() {
         // Default values for username and email
         pubname := "N/A"
         pubmail := "N/A"
+        isAdmin := "[ ]"
 
         // Query User API for more information on user
         user, _, _ := client.Users.Get(*v.Login)
+
+        // Query Organization API for user membership
+        membership, _, _ := client.Organizations.GetOrgMembership(*user.Login, *org_name)
+        if *membership.Role == "admin" {
+            isAdmin = "[*]"
+        }
         
         // Check if user has a name that is public
         if user.Name != nil {
@@ -145,7 +153,8 @@ func main() {
             }
         }
 
-        fmt.Printf("%02d: %s (%s) - %s\n", counter, *user.Login, pubname, pubmail)
+        fmt.Printf("%02d: %s %s (%s) - %s\n", counter, isAdmin, *user.Login, pubname, pubmail)
         counter++
     }
+    fmt.Println("* - denotes organization admin")
 }


### PR DESCRIPTION
- Added command line flags
- Added absolute path to the whitelist (and removed the requirement for a whitelist
- Added the ability to check email addresses in the whitelist
- Added error on invalid token
- Added warning if using `2fa_disabled` filter and not owner of the organization
- Added the ability to disable the `2fa_disabled` filter
- Added output that shows admins of the organization via `[*]`
- Updated README with command line flags and examples
